### PR TITLE
Aggregation bucket align (for RedisTimeSeries >= 1.6.0)

### DIFF
--- a/redistimeseries/src/main/java/io/github/dengliming/redismodule/redistimeseries/Align.java
+++ b/redistimeseries/src/main/java/io/github/dengliming/redismodule/redistimeseries/Align.java
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 
-package io.github.dengliming.redismodule.redistimeseries.protocol;
+package io.github.dengliming.redismodule.redistimeseries;
 
 /**
- * @author dengliming
+ * Aggregation Align type
+ *
+ * @author xdev.developer
  */
-public enum Keywords {
+public enum Align {
+    START("start"), END("end");
 
-    RETENTION, UNCOMPRESSED, LABELS, TIMESTAMP, AGGREGATION, COUNT, WITHLABELS, FILTER, DUPLICATE_POLICY, ON_DUPLICATE, ALIGN;
+    private String key;
 
+    Align(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
 }

--- a/redistimeseries/src/main/java/io/github/dengliming/redismodule/redistimeseries/RangeOptions.java
+++ b/redistimeseries/src/main/java/io/github/dengliming/redismodule/redistimeseries/RangeOptions.java
@@ -27,6 +27,7 @@ public class RangeOptions {
 
     private int count;
     private Aggregation aggregationType;
+    private Align aggregationAlign;
     private long timeBucket;
     private boolean withLabels;
 
@@ -38,6 +39,13 @@ public class RangeOptions {
     public RangeOptions aggregationType(Aggregation aggregationType, long timeBucket) {
         this.aggregationType = aggregationType;
         this.timeBucket = timeBucket;
+        return this;
+    }
+
+    public RangeOptions aggregationType(Aggregation aggregationType, long timeBucket, Align align) {
+        this.aggregationType = aggregationType;
+        this.timeBucket = timeBucket;
+        this.aggregationAlign = align;
         return this;
     }
 
@@ -55,6 +63,10 @@ public class RangeOptions {
             args.add(Keywords.AGGREGATION);
             args.add(aggregationType.getKey());
             args.add(timeBucket);
+            if (aggregationAlign != null) {
+                args.add(Keywords.ALIGN);
+                args.add(aggregationAlign.getKey());
+            }
         }
         if (withLabels) {
             args.add(Keywords.WITHLABELS);

--- a/redistimeseries/src/test/java/io/github/dengliming/redismodule/redistimeseries/RedisTimeSeriesTest.java
+++ b/redistimeseries/src/test/java/io/github/dengliming/redismodule/redistimeseries/RedisTimeSeriesTest.java
@@ -17,9 +17,12 @@
 package io.github.dengliming.redismodule.redistimeseries;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.redisson.client.RedisException;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 
@@ -150,6 +153,76 @@ public class RedisTimeSeriesTest extends AbstractTest {
         timeSeries = redisTimeSeries.mrange(timestamp, timestamp + 1, new RangeOptions()
                 .max(3).withLabels(), "sensor_id=1");
         assertThat(timeSeries).isEmpty();
+    }
+
+    @Test
+    public void testAggregations() {
+        RedisTimeSeries redisTimeSeries = getRedisTimeSeries();
+        long timestamp = System.currentTimeMillis();
+        String sensor = "temperature:sum";
+
+        assertThat(redisTimeSeries.incrBy(sensor, 10, timestamp, new TimeSeriesOptions()
+                .retentionTime(6000L)
+                .unCompressed()).longValue()).isEqualTo(timestamp);
+
+        assertThat(redisTimeSeries.incrBy(sensor, 20, timestamp + 1).longValue()).isEqualTo(timestamp + 1);
+
+        List<Value> values = redisTimeSeries.range(sensor, timestamp, timestamp + 1);
+        assertThat(values).hasSize(2);
+
+        List<Value> sum = redisTimeSeries.range(sensor, timestamp, timestamp + 10, new RangeOptions()
+                .aggregationType(Aggregation.SUM, 60000L));
+
+        assertThat(sum).hasSize(1);
+        // Timestamp trimmed to timeBucket (minutes)
+        assertThat(sum.get(0).getTimestamp()).isEqualTo(Instant.ofEpochMilli(timestamp).truncatedTo(ChronoUnit.MINUTES).toEpochMilli());
+        assertThat(sum.get(0).getValue()).isEqualTo(40.0d);
+    }
+
+    @Ignore("Only for redis timeseries > 1.6.0")
+    public void testAggregationsAlign() {
+        RedisTimeSeries redisTimeSeries = getRedisTimeSeries();
+        long from = 1L;
+        long to = 10000L;
+        long timeBucket = 3000L;
+
+        String sensor = "temperature:sum:align";
+        TimeSeriesOptions options = new TimeSeriesOptions().unCompressed();
+
+        /*
+           TS:  1000 | 2000 | 3000 | 4000
+           VAL: 1    | 1    | 10   | 10
+           BT : -------------------|-----
+         */
+
+        assertThat(redisTimeSeries.add(new Sample(sensor, Value.of(1000L, 1.0d)), options).longValue()).isEqualTo(1000L);
+        assertThat(redisTimeSeries.add(new Sample(sensor, Value.of(2000L, 1.0d)), options).longValue()).isEqualTo(2000L);
+        assertThat(redisTimeSeries.add(new Sample(sensor, Value.of(3000L, 10.0d)), options).longValue()).isEqualTo(3000L);
+        assertThat(redisTimeSeries.add(new Sample(sensor, Value.of(4000L, 10.0d)), options).longValue()).isEqualTo(4000L);
+
+        List<Value> values = redisTimeSeries.range(sensor, from, to);
+        assertThat(values).hasSize(4);
+
+        List<Value> start = redisTimeSeries.range(sensor, from, to, new RangeOptions()
+                .aggregationType(Aggregation.SUM, timeBucket, Align.START));
+
+        assertThat(start).hasSize(2);
+        assertThat(start.get(0).getTimestamp()).isEqualTo(from);
+        assertThat(start.get(0).getValue()).isEqualTo(12.0d);
+
+        assertThat(start.get(1).getTimestamp()).isEqualTo(from + timeBucket);
+        assertThat(start.get(1).getValue()).isEqualTo(10.0d);
+
+        List<Value> end = redisTimeSeries.range(sensor, from, to, new RangeOptions()
+                .aggregationType(Aggregation.SUM, timeBucket, Align.END));
+
+        assertThat(end).hasSize(2);
+
+        assertThat(end.get(0).getTimestamp()).isEqualTo(1000L);
+        assertThat(end.get(0).getValue()).isEqualTo(12.0d);
+
+        assertThat(end.get(1).getTimestamp()).isEqualTo(4000L);
+        assertThat(end.get(1).getValue()).isEqualTo(10.0d);
     }
 
     @Test


### PR DESCRIPTION
Aggregation align support.
```
ALIGN - Time bucket alignment control for AGGREGATION. This will control the time bucket timestamps by changing the reference timestamp on which a bucket is defined. Possible values:

start or - : The reference timestamp will be the query start interval time ( fromTimestamp ).
end or + : The reference timestamp will be the query end interval time ( toTimestamp ).
A specific timestamp: align the reference timestamp to a specific time.
Note: when not provided alignment is set to 0 .
```