### PR TITLE
fix: fix the Highlighting command argument in redisearch module

### DIFF
--- a/redisearch/src/main/java/io/github/dengliming/redismodule/redisearch/search/HighlightOptions.java
+++ b/redisearch/src/main/java/io/github/dengliming/redismodule/redisearch/search/HighlightOptions.java
@@ -42,6 +42,7 @@ public class HighlightOptions {
         args.add(Keywords.HIGHLIGHT);
         if (fields != null) {
             args.add(Keywords.FIELDS);
+            args.add(fields.length);
             for (String field : fields) {
                 args.add(field);
             }


### PR DESCRIPTION
fix the highlighting argument in redisearch module,it is missing a parameter